### PR TITLE
Improved swagger docs

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -27,6 +27,7 @@ requests = ">=2.18.1"
 # Are these necessary?:
 eventlet = "*"
 greenlet = "*"
+blinker = "*"
 
 [dev-packages]
 codecov = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a55b629300bc68f4863bdcfeaf5953571d19393e9490139e917402ef7f93ffbc"
+            "sha256": "50ac64f504f7d07668057a20d3bd188b400a3846efd271733207b577fb0f1908"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -55,6 +55,13 @@
                 "sha256:d4d2fed1a251ea58eed47b48db3778ebb92f5ff4407dc91869c6f41c3a9249d0"
             ],
             "version": "==3.3.0.23"
+        },
+        "blinker": {
+            "hashes": [
+                "sha256:471aee25f3992bd325afa3772f1063dbdbbca947a041b8b89466dc00d606f8b6"
+            ],
+            "index": "pypi",
+            "version": "==1.4"
         },
         "celery": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -9,10 +9,20 @@ information about past, present, and upcoming events.
 
 ## Using
 
-As a user, the main interface to ABE is ABE's web calendar front end,
-[abe-web][abe-web].
+### As a Calendar User
 
-Interactive API documentation can be found at`/docs/`, e.g. for local development: <http://127.0.0.1:3000/docs/>.
+You want ABE's web calendar front end, [abe-web][abe-web].
+
+## As a Developer
+
+The ABE API lets an application read and modify events, labels, and calendar
+subscriptions. Read about ABE's API documentation
+[here](https://github.com/olin-build/ABE/wiki/ABE-API).
+
+ABE can also be used to verify that a user is inside the Olin intranet, and/or
+is a member of the Olin community (as demonstrated by possession of an
+`olin.edu` email address). See the documentation on [Sign in with
+ABE](https://github.com/olin-build/ABE/wiki/Sign-in-with-ABE).
 
 ## Contributing
 

--- a/abe/auth/access_tokens.py
+++ b/abe/auth/access_tokens.py
@@ -68,9 +68,8 @@ def get_access_token_scope(token):
 def is_valid_token(token):
     if not token:
         return False
-    enc = token.encode()
     try:
-        jwt.decode(enc, ACCESS_TOKEN_SECRET, algorithms='HS256')  # for effect
+        jwt.decode(token.encode(), ACCESS_TOKEN_SECRET, algorithms='HS256')  # for effect
     except Exception:
         return False
     return True

--- a/abe/database.py
+++ b/abe/database.py
@@ -6,13 +6,9 @@ import re
 
 from mongoengine import connect
 
-# These imports are for effect. They define the document types, that mongodb
+# This import is for effect. It defines the document types, that mongodb
 # uses to unserialize.
-from .document_models.app_documents import App  # noqa: F401
-from .document_models.event_documents import Event, RecurringEventExc  # noqa: F401
-from .document_models.ics_documents import ICS  # noqa: F401
-from .document_models.label_documents import Label  # noqa: F401
-from .document_models.subscription_documents import Subscription  # noqa: F401
+from .document_models import *  # noqa: F401,F403
 
 
 # Support legacy environment variable names

--- a/abe/document_models/__init__.py
+++ b/abe/document_models/__init__.py
@@ -1,0 +1,9 @@
+# These imports are for effect. They define the document types, that mongodb
+# uses to unserialize.
+from .app_documents import App  # noqa: F401
+from .event_documents import Event, RecurringEventExc  # noqa: F401
+from .ics_documents import ICS  # noqa: F401
+from .label_documents import Label  # noqa: F401
+from .subscription_documents import Subscription  # noqa: F401
+
+from .event_documents import VISIBILITY  # noqa: F401

--- a/abe/document_models/app_documents.py
+++ b/abe/document_models/app_documents.py
@@ -4,13 +4,33 @@ from uuid import uuid4
 import flask.json
 from mongoengine import Document, ListField, StringField, URLField
 
-BUILTIN_APPS_PATH = Path(__file__).parent / f'../data/builtin-apps.json'
+from ..helper_functions.mongodb_helpers import Document__repr__, Document__str__
+
+BUILTIN_APPS_PATH = Path(__file__).parent / '../data/builtin-apps.json'
 
 
 class App(Document):
     """
     Model for OAuth applications
     """
+    __repr__ = Document__repr__
+    __str__ = Document__str__
+
+    @classmethod
+    def admin_app(cls):
+        return cls.force_client(role='admin')
+
+    @classmethod
+    def force_client(cls, role):
+        app = cls.objects(role=role).first()
+        if not app:
+            apps_data = flask.json.loads(BUILTIN_APPS_PATH.read_text())
+            data = next(d for d in apps_data if d['role'] == role)
+            data['client_id'] = uuid4().hex
+            app = cls(**data)
+            app.save()
+        return app
+
     name = StringField(required=True, unique=True)
     short_description = StringField()
     long_description = StringField()
@@ -24,22 +44,6 @@ class App(Document):
     # builtins
     role = StringField()
     redirect_prefixes = ListField(StringField())  # non-URL prefixes for builtins
-
-    @classmethod
-    def admin_app(cls):
-        return cls.force_client(role='admin')
-
-    @classmethod
-    def force_client(cls, role):
-        app = cls.objects(role=role).first()
-        if not app:
-            with open(BUILTIN_APPS_PATH) as fp:
-                apps_data = flask.json.load(fp)
-            data = next(d for d in apps_data if d['role'] == role)
-            data['client_id'] = uuid4().hex
-            app = cls(**data)
-            app.save()
-        return app
 
     def validate_redirect_uri(self, redirect_uri):
         redirect_uris = self.redirect_uris + self.redirect_prefixes

--- a/abe/document_models/event_documents.py
+++ b/abe/document_models/event_documents.py
@@ -1,57 +1,11 @@
-#!/usr/bin/env python3
 """Document models for mongoengine"""
 from bson import ObjectId
 from mongoengine import (BooleanField, DateTimeField, Document, EmailField, EmbeddedDocument, EmbeddedDocumentField,
                          EmbeddedDocumentListField, ListField, ObjectIdField, StringField, URLField)
 
+from ..helper_functions.mongodb_helpers import Document__repr__, Document__str__
+
 VISIBILITY = ['public', 'olin', 'students']
-
-
-def Document__repr__(doc, nested=False, skip_empty_values=True):
-    """Return a string containing a printable representation of a MongoDB
-    Document.
-
-    This function makes a string that would return an object of the same
-    value when passed to `eval()`, if the suitable constructors are in scope.
-
-    For example, DocumentSubclass(a=1, b="str").
-    """
-    def value_repr(v):
-        if isinstance(v, EmbeddedDocument):
-            return Document__repr__(v, nested=True, skip_empty_values=skip_empty_values)
-        else:
-            return repr(v)
-    data_iter = ((k, v) for
-                 k, v in doc._data.items()
-                 if k != '_cls')
-    if skip_empty_values:
-        data_iter = ((k, v) for k, v in data_iter if v)
-    sep = ': ' if nested else '='
-    data_repr = ', '.join("{}{}{}".format(k, sep, value_repr(v))
-                          for k, v in data_iter)
-    return '{' + data_repr + '}' if nested else f"{doc.__class__.__name__}({data_repr})"
-
-
-def Document__str__(doc, skip_empty_values=True):
-    """Return a nicely-printable string representation of a MongoDB Document.
-
-    For example, <DocumentSubclass a=1 b="str">.
-    """
-    def value_str(v):
-        if isinstance(v, EmbeddedDocument):
-            return Document__str__(v, skip_empty_values=skip_empty_values)
-        elif isinstance(v, str):
-            return repr(v)
-        else:
-            return str(v)
-    data_iter = ((k, v) for
-                 k, v in doc._data.items()
-                 if k != '_cls')
-    if skip_empty_values:
-        data_iter = ((k, v) for k, v in data_iter if v)
-    data_repr = ' '.join("{}={}".format(k, value_str(v))
-                         for k, v in data_iter)
-    return f"<{doc.__class__.__name__} {data_repr}>"
 
 
 class RecurringEventDefinition(EmbeddedDocument):

--- a/abe/document_models/label_documents.py
+++ b/abe/document_models/label_documents.py
@@ -27,7 +27,7 @@ class Label(Document):
     parent_labels 	Indicates which under which labels this label lives under. Optional
                                 Takes a list of strings with choice from the Labels database
 
-    color 			Suggested color for the lable. Optional
+    color 			Suggested color for the label. Optional
                                 Takes a string (hex string currently works)
 
     visibility 		Indicates who can see the label. Optional
@@ -38,8 +38,8 @@ class Label(Document):
     name = StringField(required=True, unique=True)
     description = StringField()
     url = URLField()
-    default = BooleanField(required=True, default=False)  # suggested to display by default
     parent_labels = ListField(StringField())  # rudimentary hierarchy of labels
     color = StringField(regex=r'#[0-9a-zA-Z]{6}')  # suggested color for label
+    default = BooleanField(required=True, default=False)  # suggested to display by default
+    protected = BooleanField(default=False)
     visibility = StringField()  # suggested visibility
-    protected = BooleanField()

--- a/abe/helper_functions/mongodb_helpers.py
+++ b/abe/helper_functions/mongodb_helpers.py
@@ -1,6 +1,7 @@
 from functools import wraps
 
 import mongoengine
+from mongoengine import EmbeddedDocument
 
 # This is sketchy, but mongoengine doesn't export a helpful base class that
 # could be used to catch all and only input-related errors (as opposed to server
@@ -29,3 +30,50 @@ def mongo_resource_errors(f):
             return {'error_type': 'validation',
                     'error_message': str(error)}, 400
     return wrapper
+
+
+def Document__repr__(doc, nested=False, skip_empty_values=True):
+    """Return a string containing a printable representation of a MongoDB
+    Document.
+
+    This function makes a string that would return an object of the same
+    value when passed to `eval()`, if the suitable constructors are in scope.
+
+    For example, DocumentSubclass(a=1, b="str").
+    """
+    def value_repr(v):
+        if isinstance(v, EmbeddedDocument):
+            return Document__repr__(v, nested=True, skip_empty_values=skip_empty_values)
+        else:
+            return repr(v)
+    data_iter = ((k, v) for
+                 k, v in doc._data.items()
+                 if k != '_cls')
+    if skip_empty_values:
+        data_iter = ((k, v) for k, v in data_iter if v)
+    sep = ': ' if nested else '='
+    data_repr = ', '.join("{}{}{}".format(k, sep, value_repr(v))
+                          for k, v in data_iter)
+    return '{' + data_repr + '}' if nested else f"{doc.__class__.__name__}({data_repr})"
+
+
+def Document__str__(doc, skip_empty_values=True):
+    """Return a nicely-printable string representation of a MongoDB Document.
+
+    For example, <DocumentSubclass a=1 b="str">.
+    """
+    def value_str(v):
+        if isinstance(v, EmbeddedDocument):
+            return Document__str__(v, skip_empty_values=skip_empty_values)
+        elif isinstance(v, str):
+            return repr(v)
+        else:
+            return str(v)
+    data_iter = ((k, v) for
+                 k, v in doc._data.items()
+                 if k != '_cls')
+    if skip_empty_values:
+        data_iter = ((k, v) for k, v in data_iter if v)
+    data_repr = ' '.join("{}={}".format(k, value_str(v))
+                         for k, v in data_iter)
+    return f"<{doc.__class__.__name__} {data_repr}>"

--- a/abe/resource_models/app_resources.py
+++ b/abe/resource_models/app_resources.py
@@ -4,21 +4,39 @@ from flask_restplus import Namespace, Resource, fields
 
 from abe import database as db
 from abe.auth import require_scope
-from abe.helper_functions.converting_helpers import mongo_to_dict, request_to_dict
+from abe.helper_functions.converting_helpers import request_to_dict
 from abe.helper_functions.mongodb_helpers import mongo_resource_errors
 
 api = Namespace('apps',
-                description='Create and update apps that are registered to OAuth against ABE.')
+                description="Applications that can sign in users, and use their credentials to access ABE data. "
+                "Also see the wiki pages on "
+                "[user authentication](https://github.com/olin-build/ABE/wiki/User-Authentication) "
+                "and [sign in with ABE](https://github.com/olin-build/ABE/wiki/Sign-in-with-ABE)."
+                )
 
 # This should be kept in sync with the document model, which drives the format
-app_model = api.model("App", {
-    "name": fields.String(required=True),
-    "short_description": fields.String,
-    "long_description": fields.String,
-    "url": fields.String,
-    # "client_id": fields.String(required=True),
-    "redirect_uris": fields.List(fields.String),
-    "scopes": fields.List(fields.String),
+model = api.model("App", {
+    "client_id": fields.String(
+        readOnly=True,
+        description="The API server creates this. Use it in the "
+        "[OAuth flow](https://github.com/olin-build/ABE/wiki/User-Authentication)."
+    ),
+    "name": fields.String(example="Awesome App"),
+    "short_description": fields.String(
+        description="A short description. Not currently used."),
+    "long_description": fields.String(
+        description="A few lines that are displayed in the sign in form."),
+    "url": fields.String(
+        description="Your app's home page. Not currently used.",
+        example="https://awesome.olin.build"),
+    "redirect_uris": fields.List(
+        fields.String,
+        description="The OAuth 2.0 `redirect_uri` must begin with one of these.",
+        example=["http://127.0.0.1:3000/"]),
+    "scopes": fields.List(
+        fields.String,
+        description="Ignore this, for now",
+        example=["read"]),
 })
 
 
@@ -26,51 +44,59 @@ class AppApi(Resource):
 
     @mongo_resource_errors
     @require_scope('admin:apps')
-    def get(self, id=None):
+    @api.doc(security=[{'oauth2': ['admin']}])
+    @api.marshal_with(model)
+    def get(self, client_id=None):
         """Retrieve a single application by id, or a list of apps"""
         if id:
-            result = db.App.objects(client_id=id).first()
+            result = db.App.objects(client_id=client_id).first()
             if not result:
-                return "App not found with identifier '{}'".format(id), 404
-            return mongo_to_dict(result)
-        else:
-            return [mongo_to_dict(result) for result in db.App.objects()]
+                return "App not found with identifier '{}'".format(client_id), 404
+            return result
+        return list(db.App.objects())
 
     @require_scope('admin:apps')
     @mongo_resource_errors
-    @api.expect(app_model)
+    @api.expect(model)
+    @api.marshal_with(model)
     def post(self):
-        """Create an app"""
+        """Create an app.
+
+        The API server creates the `client_id`.
+        Use it in the [authentication flow](https://github.com/olin-build/ABE/wiki/User-Authentication).
+        """
         data = request_to_dict(request)
         data['client_id'] = uuid4().hex
         app = db.App(**data)
         app.save()
-        return mongo_to_dict(app), 201
+        return app, 201
 
     @require_scope('admin:apps')
     @mongo_resource_errors
-    @api.expect(app_model)
-    def put(self, id):
+    @api.expect(model)
+    @api.marshal_with(model)
+    def put(self, client_id):
         """Update an app"""
         data = request_to_dict(request)
-        result = db.App.objects(client_id=id).first()
+        result = db.App.objects(client_id=client_id).first()
         if not result:
-            return "App not found with identifier '{}'".format(id), 404
+            return "App not found with identifier '{}'".format(client_id), 404
         result.update(**data)
-        return mongo_to_dict(result)
+        return result
 
     @require_scope('admin:apps')
     @mongo_resource_errors
-    def delete(self, id):
+    @api.marshal_with(model)
+    def delete(self, client_id):
         """Delete an app"""
-        result = db.App.objects(client_id=id).first()
+        result = db.App.objects(client_id=client_id).first()
         if not result:
-            return "App not found with identifier '{}'".format(id), 404
+            return "App not found with identifier '{}'".format(client_id), 404
         result.delete()
-        return mongo_to_dict(result)
+        return result
 
 
 api.add_resource(AppApi, '/', methods=['GET', 'POST'], endpoint='app')
-api.add_resource(AppApi, '/<string:id>',
+api.add_resource(AppApi, '/<string:client_id>',
                  methods=['GET', 'PUT', 'PATCH', 'DELETE'],
                  endpoint='app_id')

--- a/abe/resource_models/event_resources.py
+++ b/abe/resource_models/event_resources.py
@@ -19,25 +19,29 @@ from abe.helper_functions.recurring_helpers import placeholder_recurring_creatio
 from abe.helper_functions.sub_event_helpers import (access_sub_event, create_sub_event, find_recurrence_end,
                                                     sub_event_to_full, update_sub_event)
 
-api = Namespace('events', description='Events related operations')
+api = Namespace(
+    'events', description="iCalendar events. [RFC 5545](https://tools.ietf.org/html/rfc5545) describes the fields.")
 
 # This should be kept in sync with the document model, which drives the format
-event_model = api.model('Event_Model', {
+model = api.model('Event', {
     'title': fields.String(example="Tea time"),
     'start': fields.DateTime(dt_format='iso8601'),
     'end': fields.DateTime(dt_format='iso8601'),
     'location': fields.String(example="EH4L"),
-    'description': fields.String(example="Time for tea"),
+    'description': fields.String(example="Time for tea", documentation="The Markdown event description."),
     'visibility': fields.String(enum=['public', 'olin', 'students']),
-    'labels': fields.List(fields.String, description="One of the labels in the DB"),
+    'labels': fields.List(fields.String, description="A list of Labels"),
     'allDay': fields.Boolean
 })
 
 
-events_model = api.schema_model('Events_Model', {
-    'type': 'array',
-    'items': {'$ref': 'Event_Model'}}
-)
+# TODO: document that get() returns a single event OR a list. The following is
+# apparently not how to do this: the generated /doc page contains a number of
+# "Resolver error" warnings.
+#
+# model_list = api.schema_model('Event list', {'type': 'array', 'items':
+#     {'$ref': 'Event'}}
+# )
 
 
 def check_protected_labels(label_list):
@@ -50,11 +54,12 @@ def check_protected_labels(label_list):
 
 @api.route('/<event_id>/<rec_id>')
 class EventApi(Resource):
-    """API for interacting with events"""
+    """Calendar events"""
 
     @api.doc(params={'event_id': 'The optional event id',
                      'rec_id': 'The optional sub-event id'})
-    @api.response(200, 'Success', events_model)
+    @api.response(200, 'Success', model)
+    @api.doc(security=[])
     @mongo_resource_errors
     def get(self, event_id=None, rec_id=None):
         if event_id:
@@ -125,8 +130,8 @@ class EventApi(Resource):
 
     @require_scope('create:events')
     @mongo_resource_errors
-    @api.expect(event_model)
-    @api.response(201, 'Created', event_model)
+    @api.expect(model)
+    @api.response(201, 'Created', model)
     @api.doc(responses={400: 'Validation Error',
                         401: 'Unauthorized Access'})
     def post(self):
@@ -147,7 +152,7 @@ class EventApi(Resource):
 
     @require_scope('edit:events')
     @mongo_resource_errors
-    @api.expect(event_model)
+    @api.expect(model)
     def put(self, event_id):
         """
         Modify individual event
@@ -214,10 +219,9 @@ class EventApi(Resource):
 
 
 api.add_resource(EventApi, '/', methods=['GET', 'POST'], endpoint='event')
-# TODO: add route for string/gphycat links
 api.add_resource(EventApi, '/<string:event_id>',
                  methods=['GET', 'PUT', 'PATCH', 'DELETE'],
                  endpoint='event_id')
-api.add_resource(EventApi, '/<string:event_id>/<string:rec_id>',
-                 methods=['GET', 'PUT', 'PATCH', 'DELETE'],
-                 endpoint='rec_id')  # TODO: add route for string/gphycat links
+# api.add_resource(EventApi, '/<string:event_id>/<string:rec_id>',
+#                  methods=['GET', 'PUT', 'PATCH', 'DELETE'],
+#                  endpoint='rec_id')  # TODO: add route for string/gphycat links

--- a/abe/resource_models/subscription_resources.py
+++ b/abe/resource_models/subscription_resources.py
@@ -16,7 +16,7 @@ from flask_restplus import Namespace, Resource, fields
 api = Namespace('subscriptions', description='iCalendar subscriptions')
 
 # This should be kept in sync with the document model, which drives the format
-sub_model = api.model('Sub_Model', {
+model = api.model('Subscription', {
     "labels": fields.List(fields.String)
 })
 
@@ -46,7 +46,7 @@ class SubscriptionAPI(Resource):
         return subscription_to_dict(subscription)
 
     @mongo_resource_errors
-    @api.expect(sub_model)
+    @api.expect(model)
     def post(self, subscription_id: str = ''):
         """
         Creates a subscription object with a list of labels, returning it with an ID
@@ -70,7 +70,7 @@ class SubscriptionAPI(Resource):
         return subscription_to_dict(subscription)
 
     @mongo_resource_errors
-    @api.expect(sub_model)
+    @api.expect(model)
     def put(self, subscription_id: str):
         """Modify an existing subscription"""
 
@@ -96,6 +96,7 @@ class SubscriptionICS(Resource):
     """Retrieves data from the given subscription as an ICS feed"""
 
     @mongo_resource_errors
+    @api.doc(security=[])
     def get(self, subscription_id: str):
         """
         Returns an ICS feed when requested.
@@ -131,6 +132,5 @@ api.add_resource(SubscriptionAPI, '/', methods=['POST'],
                  endpoint='subscription')
 api.add_resource(SubscriptionAPI, '/<string:subscription_id>',
                  methods=['GET', 'PUT', 'POST'], endpoint='subscription_id')
-
 api.add_resource(SubscriptionICS, '/<string:subscription_id>/ics',
                  methods=['GET'], endpoint='subscription_ics')

--- a/abe/resource_models/user_resources.py
+++ b/abe/resource_models/user_resources.py
@@ -1,38 +1,51 @@
 from flask import request
 from flask_restplus import Namespace, Resource, fields
 
-from abe.auth import (get_access_token_provider, get_access_token_role, get_access_token_scope, request_access_token
-                      )
+from abe.auth import (get_access_token_provider, get_access_token_role, get_access_token_scope, request_access_token,
+                      request_is_from_inside_intranet)
 
-api = Namespace('user', description='User info')
+api = Namespace('user', description="User information and authorization.")
 
-resource_model = api.model("User", {
-    "authenticated": fields.Boolean(
+resource_model = api.model('User', {
+    'authenticated': fields.Boolean(
         default=False,
-        required=True,
-        description="The client has been authenticated or is inside the intranet."),
-    # "inside_intranet": fields.Boolean(
-    #     required=True,
-    #     description="The client is inside the intranet."),
-    "provider": fields.String(enum=['intranet', 'email', 'slack']),
-    "role": fields.String(enum=['user', 'admin']),
-    "scope": fields.List(
+        description="""The user has been authenticated. This includes **implicit "authentication**, which is granted \
+        to anyone visiting from inside the intranet (and may remain when the same user agent visits again from \
+        outside).""",
+    ),
+    'inside_intranet': fields.Boolean(
+        description="""The user agent is [inside the \
+        intranet](http://tvtropes.org/pmwiki/pmwiki.php/Main/TheCallsAreComingFromInsideTheHouse).""",
+    ),
+    'provider': fields.String(
+        enum=['intranet', 'email', 'slack'],
+        description="""How did the user sign in?\n\n`"intranet"` means they were *implicitly* authenticated, by \
+        visiting from inside the intranet.""",
+    ),
+    'role': fields.String(
+        description="The user's role. You probably want to check the scope instead.",
+        enum=['user', 'admin']
+    ),
+    'scope': fields.List(
         fields.String, required=True, default=[],
-        description="The OAuth scope."),
+        description="A list of authorization scopes that have been granted to the user.",
+    ),
 })
 
 
 class UserApi(Resource):
-    """Account information for the authenticated user."""
 
     @api.marshal_with(resource_model)
+    @api.doc(security=[])
     def get(self):
+        """Get information about the currently-authenticated user.
+        Also, whether the client is inside the intranet."""
         access_token = request_access_token(request)
         if not access_token:
             return None
         return {
             'authenticated': bool(access_token),
-            # 'inside_intranet': request_is_from_inside_intranet(request),
+            'inside_intranet': request_is_from_inside_intranet(request),
             'provider': get_access_token_provider(access_token),
             'role': get_access_token_role(access_token),
             'scope': get_access_token_scope(access_token),

--- a/abe/routes/admin_routes.py
+++ b/abe/routes/admin_routes.py
@@ -6,6 +6,8 @@ from itsdangerous import Signer
 
 from abe import database as db
 
+from ..resource_models.user_resources import UserApi
+
 profile = Blueprint('admin', __name__)
 
 
@@ -17,7 +19,7 @@ def signer():
 def login():
     # This is a roundabout way of logging in, but it exercises the same OAuth
     # flow that client apps use, so it doubles as testing that flow.
-    redirect_uri = url_for('admin.login_auth')
+    redirect_uri = url_for('admin.login_token')
     iat = int(time.time())
     sig = signer().sign(str(iat).encode())
     return redirect(url_for('oauth.authorize',
@@ -30,23 +32,38 @@ def login():
 
 @profile.route('/logout')
 def logout():
+    "Remove the auth token from the session, and redirect to redirect_uri or to the login page."
     session.pop('access_token', None)
-    redirect_uri = 'login'
+    redirect_uri = request.args.get('redirect_uri', url_for('admin.login'))
     return redirect('/oauth/deauthorize?redirect_uri=' + url_quote_plus(redirect_uri))
 
 
-@profile.route('/account/info')
-def login_auth():
-    iat = signer().unsign(request.args['state'])
-    age = int(time.time()) - int(iat)
-    # Allow this many minutes to use a link. This is unlikely for sign in with
-    # slack, but reasonable for email if the user comes back to it later.
-    if age > 30 * 60:
-        flash('This link has expired. Please try again.')
-        return redirect(url_for('login'))
+@profile.route('/login/token')
+def login_token():
+    "Store the auth token in the session, and redirect to redirect_uri or to the account info page."
+    if 'state' in request.args and '.' in request.args['state']:
+        iat = signer().unsign(request.args['state'])
+        age = int(time.time()) - int(iat)
+        # Allow this many minutes to use a link. This is unlikely for sign in with
+        # slack, but reasonable for email if the user comes back to it later.
+        if age > 30 * 60:
+            flash('This link has expired. Please try again.')
+            return redirect(url_for('admin.login'))
     session['access_token'] = request.args['access_token']
-    return render_template('account.html', args=request.args, age=age)
+    return redirect(request.args.get('redirect_uri', url_for('admin.account_info')))
 
+
+@profile.route('/account/info')
+def account_info():
+    "Display account info, for debugging."
+    info = UserApi().get()
+    info['access_token'] = session.get('access_token')
+    info = dict(sorted(info.items()))
+    return render_template('account.html', info=info)
+
+
+# TODO:The following routes haven't been used in a while, to my knowledge. is it
+#  okay to remove them? [ows 2018-05]
 
 @profile.route('/add_event')
 def add_event():

--- a/abe/routes/oauth_routes.py
+++ b/abe/routes/oauth_routes.py
@@ -37,9 +37,8 @@ def unsign_json(param):
 
 @profile.route('/oauth/authorize')
 def authorize():
-    if 'response_type' not in request.args:
-        abort(400, 'missing response_type')
-    if request.args['response_type'] != 'token':
+    # TODO: document and validate with swagger
+    if request.args.get('response_type', 'token') != 'token':
         abort(400, 'invalid response_type')
     if 'redirect_uri' not in request.args:
         abort(400, 'missing redirect_uri')
@@ -164,7 +163,11 @@ def auth_send_email():
         body = render_template('oauth_email_body.html', email_auth_link=email_auth_link)
         msg.attach(MIMEText(body, 'html', 'utf-8'))
         if send_message(msg):
-            return render_template('email_login.html', email_sent=True, email=email)
+            return render_template('email_login.html',
+                                   email_sent=True,
+                                   email=email,
+                                   link_prefix=request.url_root,
+                                   )
         else:
             flash("Failed to send email. Check the server log.")
     for field, errors in form.errors.items():

--- a/abe/sample_data.py
+++ b/abe/sample_data.py
@@ -144,7 +144,7 @@ def load_data(db):
 def main(events=None, labels=None):
     """Load the database with sample data.
 
-    With no options, uses samples from this source file."""
+    With no options, loads the data from ./tests/data file."""
 
     from . import database as db
     event_data = load_event_data(events) if events else None

--- a/abe/templates/account.html
+++ b/abe/templates/account.html
@@ -16,18 +16,19 @@
 </head>
 <body>
     <div>
-        <h1>Account Info</h1>
+        <h1>User Info</h1>
         <p>
             This page is for debugging OAuth.
         </p>
 
         <a href="/logout">Sign Out</a>
 
+        <hr/>
         <table>
-            {% for k in args %}
+            {% for k in info %}
                 <tr>
                     <th>{{ k }}</th>
-                    <td>{{ args[k] }}</td>
+                    <td>{{ info[k] }}</td>
                 </tr>
             {% endfor %}
         </table>

--- a/abe/templates/email_login.html
+++ b/abe/templates/email_login.html
@@ -23,8 +23,16 @@
         {% endif %}
     {% endwith %}
     {% if email_sent %}
-        <p>A sign-in link has been sent to {{ email }}.</p>
+        <p>A sign-in link has been sent to <code>{{ email }}</code>.</p>
         <p>When this link arrives, click on it to sign into ABE.</p>
+        <h2>Security Tips</h2>
+        <ul>
+        <li>The link will begin with “<code>{{link_prefix }}</code>”. That's the
+        same hostname as this page.</li>
+        <li>You will <em>not</em> be asked to enter any information into the
+        page that the link takes you to.</li>
+        </ul>
+
     {% else %}
         <div class="warning">{{ message }}</div>
         <div>

--- a/tests/data/sample-apps.json
+++ b/tests/data/sample-apps.json
@@ -5,7 +5,6 @@
         "long_description":
             "The Olin Community calendar is an olin.build project that collects and presents events from the Olin community.",
         "url": "https://events.olin.build",
-        "client_id": "5bbf864ff1274dea9ca739030a37df28",
         "redirect_uris": ["http://127.0.0.1:8080/", "http://localhost:8080/"],
         "scopes": ["admin:*"]
     }

--- a/tests/data/sample-events.json
+++ b/tests/data/sample-events.json
@@ -37,8 +37,8 @@
     {
         "visibility": "students",
         "title": "First Day of Work!",
-        "start": "2017-06-01:09:15:00",
-        "end": "2017-06-01:17:00:00",
+        "start": "2017-06-01T09:15:00",
+        "end": "2017-06-01T17:00:00",
         "description": "Bring clothes to work/paint in",
         "location": "Library",
         "labels": ["summer", "library", "OWL", "SOS"]

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -17,15 +17,16 @@ class AdminTestCase(unittest.TestCase):
             self.assertEqual(response.status_code, 302)
             self.assertEqual(re.sub(r'\?.*', '', response.location), 'http://localhost/oauth/authorize')
             params = dict(parse_qsl(urlparse(response.location).query))
-            self.assertEqual(params['redirect_uri'], '/account/info')
+            self.assertEqual(params['redirect_uri'], '/login/token')
             self.assertEqual(params['response_type'], 'token')
-            self.assertRegex(params['state'], r'(?i)\d+\.[_0-9a-z]+')
+            self.assertRegex(params['state'], r'[^.]+.[^.]+')
 
         with self.subTest("handles redirection from oauth"):
             token = user_access_token
             url = f"{params['redirect_uri']}?state={params['state']}&access_token={token}"
             response = client.get(url)
-            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.status_code, 302)
+            self.assertEqual(response.location, 'http://localhost/account/info')
 
         with self.subTest("sets authorization"):
             response = client.get('/user/',

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -91,6 +91,7 @@ class EventsTestCase(abe_unittest.TestCase):
                 content_type='application/json'
             )
             self.assertEqual(response.status_code, 400)
+
         with self.subTest("fails if event has protected label"):
             event = {
                 'title': 'protected post',


### PR DESCRIPTION
Add some descriptions.

Fix model names and references.

App and Label marshal with their models.

Annotate authorizations.

/doc can initate the authorization flow.

Generate a Postman file.

Link to (new) wiki pages.